### PR TITLE
#5 fixed two Gradle warnings

### DIFF
--- a/micronaut-camunda-bpm-example/build.gradle
+++ b/micronaut-camunda-bpm-example/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "net.ltgt.apt-eclipse" version "0.21"
     id "com.github.johnrengelman.shadow" version "5.2.0"
     id "application"
 }
@@ -13,7 +12,7 @@ configurations {
 }
 
 dependencies {
-    compile project(":micronaut-camunda-bpm-feature")
+    implementation project(":micronaut-camunda-bpm-feature")
     annotationProcessor platform("io.micronaut:micronaut-bom:$micronautVersion")
     annotationProcessor "io.micronaut:micronaut-inject-java"
     annotationProcessor "io.micronaut:micronaut-validation"

--- a/micronaut-camunda-bpm-feature/build.gradle
+++ b/micronaut-camunda-bpm-feature/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "net.ltgt.apt-eclipse" version "0.21"
     id "application"
 }
 


### PR DESCRIPTION
1. fix: changed compile project to implementation project
2. fix: removed "net.ltgt.apt-eclipse". See here:  https://github.com/gradle/gradle/issues/11437. Plugin is obsolete.