### PR TITLE
Allow to customize ProcessEngineConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ You may use the following properties (typically in application.yml) to configure
 | camunda.bpm          | .history-level   | auto                                         | Camunda history level, use one of [`full`, `audit`, `activity`, `none`, `auto`]. `auto` uses the level already present in the database, defaulting to `full`. |
 | camunda.bpm.database | .schema-update   | true                                         | If automatic schema update should be applied, use one of [`true`, `false`, `create`, `create-drop`, `drop-create`] |
 
+### Custom Process Engine Configuration
+
+Internally, to build Camunda `ProcessEngine` we use `ProcessEngineConfiguration`. This process can be intercepted for detailed configuration customization with the following bean:
+
+```java
+@Singleton
+@Replaces(DefaultProcessEngineConfigurationCustomizer.class)
+public class MyProcessEngineConfigurationCustomizer implements ProcessEngineConfigurationCustomizer  {
+
+    @Override
+    public void customize(ProcessEngineConfiguration configuration) {
+        // configure ProcessEngineConfiguration here, e.g.:
+        configuration.setProcessEngineName("CustomizedEngine");
+    }
+
+}
+```    
+
 ## Compatibility Matrix
 
 The following compatibility matrix shows the officially supported Micronaut and Camunda BPM versions for each release.

--- a/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/DefaultProcessEngineConfigurationCustomizer.java
+++ b/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/DefaultProcessEngineConfigurationCustomizer.java
@@ -1,0 +1,16 @@
+package info.novatec.micronaut.camunda.bpm.feature;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+
+import javax.annotation.Nonnull;
+import javax.inject.Singleton;
+
+@Singleton
+public class DefaultProcessEngineConfigurationCustomizer implements ProcessEngineConfigurationCustomizer {
+
+    @Override
+    public void customize(@Nonnull ProcessEngineConfiguration configuration) {
+        // no customization
+    }
+
+}

--- a/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/MicronautProcessEngineConfiguration.java
+++ b/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/MicronautProcessEngineConfiguration.java
@@ -29,10 +29,15 @@ public class MicronautProcessEngineConfiguration {
 
     private final DatasourceConfiguration datasourceConfiguration;
 
-    public MicronautProcessEngineConfiguration(ApplicationContext applicationContext, Configuration configuration, DatasourceConfiguration datasourceConfiguration) {
+    private final ProcessEngineConfigurationCustomizer processEngineConfigurationCustomizer;
+
+    public MicronautProcessEngineConfiguration(ApplicationContext applicationContext, Configuration configuration,
+                                               DatasourceConfiguration datasourceConfiguration,
+                                               ProcessEngineConfigurationCustomizer processEngineConfigurationCustomizer) {
         this.applicationContext = applicationContext;
         this.configuration = configuration;
         this.datasourceConfiguration = datasourceConfiguration;
+        this.processEngineConfigurationCustomizer = processEngineConfigurationCustomizer;
     }
 
     /**
@@ -58,6 +63,8 @@ public class MicronautProcessEngineConfiguration {
                 .setHistory(configuration.getHistoryLevel())
                 .setJobExecutorActivate(true)
                 .setExpressionManager(new MicronautExpressionManager(new ApplicationContextElResolver(applicationContext)));
+
+        processEngineConfigurationCustomizer.customize(processEngineConfiguration);
 
         ProcessEngine processEngine = processEngineConfiguration.buildProcessEngine();
         log.info("Successfully created process engine which is connected to database {}", datasourceConfiguration.getUrl());

--- a/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/ProcessEngineConfigurationCustomizer.java
+++ b/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/ProcessEngineConfigurationCustomizer.java
@@ -1,0 +1,15 @@
+package info.novatec.micronaut.camunda.bpm.feature;
+
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+
+import javax.annotation.Nonnull;
+
+/**
+ * @author Lukasz Frankowski
+ */
+@FunctionalInterface
+interface ProcessEngineConfigurationCustomizer {
+
+    void customize(@Nonnull ProcessEngineConfiguration configuration);
+
+}

--- a/micronaut-camunda-bpm-feature/src/test/java/info/novatec/micronaut/camunda/bpm/feature/MicronautProcessEngineConfigurationCustomizer.java
+++ b/micronaut-camunda-bpm-feature/src/test/java/info/novatec/micronaut/camunda/bpm/feature/MicronautProcessEngineConfigurationCustomizer.java
@@ -1,0 +1,19 @@
+package info.novatec.micronaut.camunda.bpm.feature;
+
+import io.micronaut.context.annotation.Replaces;
+import org.camunda.bpm.engine.ProcessEngineConfiguration;
+
+import javax.annotation.Nonnull;
+import javax.inject.Singleton;
+
+@Singleton
+@Replaces(DefaultProcessEngineConfigurationCustomizer.class)
+public class MicronautProcessEngineConfigurationCustomizer implements ProcessEngineConfigurationCustomizer {
+
+    public static final String PROCESS_ENGINE_NAME = "CustomizedEngine";
+
+    @Override
+    public void customize(@Nonnull ProcessEngineConfiguration configuration) {
+        configuration.setProcessEngineName(PROCESS_ENGINE_NAME);
+    }
+}

--- a/micronaut-camunda-bpm-feature/src/test/java/info/novatec/micronaut/camunda/bpm/feature/MicronautProcessEngineConfigurationTest.java
+++ b/micronaut-camunda-bpm-feature/src/test/java/info/novatec/micronaut/camunda/bpm/feature/MicronautProcessEngineConfigurationTest.java
@@ -72,4 +72,9 @@ class MicronautProcessEngineConfigurationTest {
     void testDeploymentName() {
         assertEquals(MicronautProcessEngineConfiguration.MICRONAUT_AUTO_DEPLOYMENT_NAME, repositoryService.createDeploymentQuery().singleResult().getName());
     }
+
+    @Test
+    void testConfigurationCustomizer() {
+        assertEquals(MicronautProcessEngineConfigurationCustomizer.PROCESS_ENGINE_NAME, processEngine.getName());
+    }
 }


### PR DESCRIPTION
Hi. I'm testing the lib and it works perfectly, however it lacks an option to customize `ProcessEngineConfiguration`. There's a dozen of `setXxx()` methods on `ProcessEngineConfiguration` which you potentially might want to customize before the `ProcessEngine` is built. 

I'm sending a simple fix for that in this pull request. The acceptable alternative is to provide `ProcessEngineConfiguration` as a bean which can be replaced. However in this scenario you would lose sensible defaults.