### PR TITLE
Make ProcessEngineConfigurationCustomizer public

### DIFF
--- a/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/ProcessEngineConfigurationCustomizer.java
+++ b/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/ProcessEngineConfigurationCustomizer.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
  * @author Lukasz Frankowski
  */
 @FunctionalInterface
-interface ProcessEngineConfigurationCustomizer {
+public interface ProcessEngineConfigurationCustomizer {
 
     void customize(@Nonnull ProcessEngineConfiguration configuration);
 


### PR DESCRIPTION
Unfortunately, guys, in the previous PR someone suggested to remove `public` from interface and now `ProcessEngineConfigurationCustomizer` is only accessible from `info.novatec.micronaut.camunda.bpm.feature` package. We didn't catch it because tests are put into exactly the same package. I'm fixing this in this PR plus I suggest to move all tests to `info.novatec.micronaut.camunda.bpm.feature.test` to avoid further problems like this :)