### PR TITLE
Close process engine on application context destroy

### DIFF
--- a/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/MicronautProcessEngineConfiguration.java
+++ b/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/MicronautProcessEngineConfiguration.java
@@ -1,6 +1,7 @@
 package info.novatec.micronaut.camunda.bpm.feature;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Factory;
 import org.camunda.bpm.engine.*;
@@ -50,6 +51,7 @@ public class MicronautProcessEngineConfiguration {
      * @throws IOException if a resource, i.e. a model, cannot be loaded.
      */
     @Context
+    @Bean(preDestroy = "close")
     public ProcessEngine processEngine() throws IOException {
         ProcessEngineConfigurationImpl processEngineConfiguration = new StandaloneProcessEngineConfiguration() {
             @Override


### PR DESCRIPTION
I spent today a lot of time to debug why mockito mocks don't work with my app. And the culprit is not properly closed process engine on application context destroy.

When you run multiple test classes with different `@MockBean`-s Micronaut creates different `ApplicationContext` for each test class before test run, and recreates all beans accordingly. This is also true for `ProcessEngine` - this bean is recreated for each test class. However, because of not invoking `ProcessEngine.close()`, the scheduler thread got stuck with the first `ProcessEngine` which was created during the first test, and therefore it had the binding to outdated `ApplicationContext` with different mocks configuration for the other tests.

It seems that if you create two `ProcessEngine`-s in your app, without closing the first one, the scheduler thread is silently not recreated and stays bound to the first created `ProcessEngine`.

After this fix now my mocks config works properly.