### PR TITLE
#91 Sending SIGINT (=CTRL-C) to shutdown the application gracefully n…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ These settings will be written to ~/.gitconfig on Unix and %APPDATA%\.gitconfig 
 
 Most importantly, please format your commit messages in the following way:
 
-* Prefix Git commit messages with the ticket number, e.g. "#42: xyz"
-* Describe WHY you are making the change, e.g. "#42: Added logback to suppress the debug messages during maven build" (not only "changed logging").
+* Prefix Git commit messages with the ticket number, e.g. "Close #42: xyz"
+* Describe WHY you are making the change, e.g. "Close #42: Added logback to suppress the debug messages during maven build" (not only "changed logging").
 
 ### Clean up commit history
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You may use the following properties (typically in application.yml) to configure
 
 | Prefix               |Property          | Default                                      | Description            |
 |----------------------|------------------|----------------------------------------------|------------------------|
-| datasources.default  | .url             | jdbc:h2:mem:micronaut-db;DB_CLOSE_DELAY=1000 | Database URL           |
+| datasources.default  | .url             | jdbc:h2:mem:default;DB_CLOSE_ON_EXIT=FALSE   | Database URL           |
 |                      | .username        | sa                                           | User name for database |
 |                      | .password        |                                              | Password for database  |
 |                      | .driver-class-name | org.h2.Driver                              | Driver for database    |

--- a/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/DatasourceConfiguration.java
+++ b/micronaut-camunda-bpm-feature/src/main/java/info/novatec/micronaut/camunda/bpm/feature/DatasourceConfiguration.java
@@ -12,7 +12,7 @@ import javax.validation.constraints.NotNull;
 @ConfigurationProperties("datasources.default")
 public interface DatasourceConfiguration {
 
-    @Bindable(defaultValue = "jdbc:h2:mem:micronaut-db;DB_CLOSE_DELAY=1000")
+    @Bindable(defaultValue = "jdbc:h2:mem:default;DB_CLOSE_ON_EXIT=FALSE")
     @NotBlank
     String getUrl();
 


### PR DESCRIPTION
…o longer results in an exception for in-memory h2 database.

See http://www.h2database.com/html/features.html

Quote:
"By default, a database is closed when the last connection is closed. However, if it is never closed, the database is closed when the virtual machine exits normally, using a shutdown hook. In some situations, the database should not be closed in this case, for example because the database is still used at virtual machine shutdown (to store the shutdown process in the database for example). For those cases, the automatic closing of the database can be disabled in the database URL."