### PR TITLE
The dependency "camunda-engine" is a transitive dependency now, i.e. …

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Do you need an example? See our example application at [/micronaut-camunda-bpm-e
 2. Add the dependency in build.gradle:
 ```groovy
 implementation("info.novatec:micronaut-camunda-bpm-feature:0.6.0")
-implementation("org.camunda.bpm:camunda-engine:7.13.0")
 runtimeOnly("com.h2database:h2")
 ```
+
+Note: The module `micronaut-camunda-bpm-feature` includes the dependency `org.camunda.bpm:camunda-engine` which will be resolved transitively.
 
 ## Add Dependency using Maven
 1. (Optionally) create an empty Micronaut project with `mn create-app my-example --build=maven` or use [Micronaut Launch](https://launch.micronaut.io).
@@ -61,16 +62,13 @@ runtimeOnly("com.h2database:h2")
   <version>0.6.0</version>
 </dependency>
 <dependency>
-  <groupId>org.camunda.bpm</groupId>
-  <artifactId>camunda-engine</artifactId>
-  <version>7.13.0</version>
-</dependency>
-<dependency>
   <groupId>com.h2database</groupId>
   <artifactId>h2</artifactId>
   <scope>runtime</scope>
 </dependency>
 ```
+
+Note: The module `micronaut-camunda-bpm-feature` includes the dependency `org.camunda.bpm:camunda-engine` which will be resolved transitively.
 
 ##  Deploying process models
 To deploy a process model create an executable BPMN file and save it in the resources' root. When starting the application you'll see the logs saying:

--- a/micronaut-camunda-bpm-example/build.gradle
+++ b/micronaut-camunda-bpm-example/build.gradle
@@ -18,7 +18,6 @@ dependencies {
     implementation(project(":micronaut-camunda-bpm-feature"))
     implementation("io.micronaut:micronaut-validation")
     implementation("io.micronaut:micronaut-runtime")
-    implementation("org.camunda.bpm:camunda-engine:$camundaVersion")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("ch.qos.logback:logback-classic")
 

--- a/micronaut-camunda-bpm-feature/build.gradle
+++ b/micronaut-camunda-bpm-feature/build.gradle
@@ -19,8 +19,7 @@ micronaut {
 dependencies {
     implementation("io.micronaut:micronaut-validation")
     implementation("io.micronaut:micronaut-runtime")
-    implementation("io.micronaut:micronaut-http-client")
-    implementation("org.camunda.bpm:camunda-engine:$camundaVersion")
+    api("org.camunda.bpm:camunda-engine:$camundaVersion")
     compileOnly("io.micronaut.data:micronaut-data-tx")
 
     // Test

--- a/micronaut-camunda-bpm-feature/transactional-test-data-jdbc/build.gradle
+++ b/micronaut-camunda-bpm-feature/transactional-test-data-jdbc/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     testImplementation project(':micronaut-camunda-bpm-feature').sourceSets.test.output
     testImplementation project(':micronaut-camunda-bpm-feature:transactional-test').sourceSets.test.output
 
-    implementation("org.camunda.bpm:camunda-engine:$camundaVersion")
     testRuntimeOnly("com.h2database:h2")
 
     // Integration of Transaction Management

--- a/micronaut-camunda-bpm-feature/transactional-test/build.gradle
+++ b/micronaut-camunda-bpm-feature/transactional-test/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     implementation project(":micronaut-camunda-bpm-feature")
     testImplementation project(':micronaut-camunda-bpm-feature').sourceSets.test.output
 
-    implementation("org.camunda.bpm:camunda-engine:$camundaVersion")
     testRuntimeOnly("com.h2database:h2")
 
     // Integration of Transaction Management


### PR DESCRIPTION
…it will be resolved automatically. A newer version can be used by adding

implementation("org.camunda.bpm:camunda-engine:7.14.0")