### PR TITLE
Update to actions/cache@v2, see also https://docs.github.com/en/free-…

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Cache Dependencies #see https://github.com/actions/cache/blob/master/examples.md#java---gradle
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}


### PR DESCRIPTION
…pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses regarding versioning of Github Actions